### PR TITLE
Sticky Footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 <footer
-  class="fixed bottom-0 left-0 z-20 w-full p-4 border-t border-gray-200 shadow md:flex md:items-center md:justify-between md:p-6 dark:bg-gray-800 dark:border-gray-600"
+  class="w-full p-4 border-t border-gray-200 shadow md:flex md:items-center md:justify-between md:p-6 dark:bg-gray-800 dark:border-gray-600"
 >
   <span class="text-sm text-gray-500 sm:text-center dark:text-gray-400"
     >EQMonitor is developed by <a

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ interface Props {
 const { title, description } = Astro.props;
 ---
 
-<html lang="ja">
+<html lang="ja" class="h-full">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -30,9 +30,11 @@ const { title, description } = Astro.props;
     />
     <title>{title}</title>
   </head>
-  <body>
+  <body class="h-full">
     <Navbar />
     <slot />
-    <Footer />
+    <div class="sticky top-[100vh]" style="top: 100dvh;">
+      <Footer />
+    </div>
   </body>
 </html>


### PR DESCRIPTION
スマホで見るとフッターが画像に被ってしまいます
![Screenshot_2024-06-03-18-59-43-133_com android chrome](https://github.com/YumNumm/eqmonitor-site/assets/67098414/b2a3698a-56f7-4019-875f-7eee2c32ca76)

よかったらこれをStickyFooterという技術でうま〜く表示してみませんか？
![Screenshot_2024-06-03-18-57-51-246_com android chrome](https://github.com/YumNumm/eqmonitor-site/assets/67098414/6e5127bb-ea27-4814-bdd3-58ecce339584)
![Screenshot_2024-06-03-18-57-53-811_com android chrome](https://github.com/YumNumm/eqmonitor-site/assets/67098414/4dc0647c-bcc7-4de3-a09a-3cb93126e33c)
![Screenshot_2024-06-03-18-57-59-045_com android chrome](https://github.com/YumNumm/eqmonitor-site/assets/67098414/e67a0591-ffb3-4b2f-a5ef-a5c66b4aad52)

基本コンテンツの下に張り付いていて、コンテンツが画面の縦幅より小さい場合のみ画面の下に固定されます
CSSだけで実現してるので重くなったりはしません